### PR TITLE
Update to Dockerfile.ros2_codeserver to fix signing

### DIFF
--- a/docker/Dockerfile.ros2_codeserver
+++ b/docker/Dockerfile.ros2_codeserver
@@ -12,10 +12,9 @@ ARG GROUP_ID
 RUN : "${USER_ID:?Build argument needs to be set and non-empty.}" && \
     : "${GROUP_ID:?Build argument needs to be set and non-empty.}"
 
-RUN apt-get update && \
-    apt-get install -y wget && \
+RUN apt-get install -y wget && \
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
Changing the order of the apt-get process solves a persistent unsigned package error that occurs with chrome previously  documented at https://github.com/hadabot/hadabot_main/issues/25